### PR TITLE
Add ability to remove default scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $authenticator =  new Authenticator(
 );
 
 $authenticationRedirectUri = $authenticator
-    ->beginAuthentication($providerConfiguration, $redirectUrl)
+    ->beginAuthentication($providerConfiguration, $redirectUrl) // you can pass false as the 3rd parameter to skip the default openid scope.
     ->withScopes('profile', 'email', 'phone')
     ->uri();
 ```

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ $authenticator =  new Authenticator(
 );
 
 $authenticationRedirectUri = $authenticator
-    ->beginAuthentication($providerConfiguration, $redirectUrl) // you can pass false as the 3rd parameter to skip the default openid scope.
-    ->withScopes('profile', 'email', 'phone')
+    ->beginAuthentication($providerConfiguration, $redirectUrl)
+    ->withScopes('profile', 'email', 'phone') // use ->withoutScopes('openid') to remove the default openid scope if needed.
     ->uri();
 ```
 

--- a/src/Authentication/AuthenticationUriBuilder.php
+++ b/src/Authentication/AuthenticationUriBuilder.php
@@ -26,12 +26,9 @@ class AuthenticationUriBuilder
     /**
      * @throws OpenIdConnectException
      */
-    public function __construct(
-        private ProviderConfigurationInterface $provider,
-        private Uri                            $redirectUri,
-        bool                                   $withDefaultScopes = true,
-    ) {
-        $this->scopes        = new Scopes($withDefaultScopes);
+    public function __construct(private ProviderConfigurationInterface $provider, private Uri $redirectUri)
+    {
+        $this->scopes        = new Scopes();
         $this->state         = State::createWithRandomString();
         $this->codeChallenge = Challenge::createWithRandomString();
     }
@@ -50,6 +47,15 @@ class AuthenticationUriBuilder
     {
         foreach ($scopes as $scope) {
             $this->scopes->addScope(new Scope($scope));
+        }
+
+        return $this;
+    }
+
+    public function withoutScopes(string ...$scopes): self
+    {
+        foreach ($scopes as $scope) {
+            $this->scopes->removeScope(new Scope($scope));
         }
 
         return $this;

--- a/src/Authentication/AuthenticationUriBuilder.php
+++ b/src/Authentication/AuthenticationUriBuilder.php
@@ -19,8 +19,6 @@ class AuthenticationUriBuilder
 
     private Scopes    $scopes;
 
-    private bool      $withDefaultScopes = true;
-
     private State     $state;
 
     private Challenge $codeChallenge;

--- a/src/Authentication/AuthenticationUriBuilder.php
+++ b/src/Authentication/AuthenticationUriBuilder.php
@@ -28,9 +28,12 @@ class AuthenticationUriBuilder
     /**
      * @throws OpenIdConnectException
      */
-    public function __construct(private ProviderConfigurationInterface $provider, private Uri $redirectUri)
-    {
-        $this->scopes        = new Scopes();
+    public function __construct(
+        private ProviderConfigurationInterface $provider,
+        private Uri                            $redirectUri,
+        bool                                   $withDefaultScopes = true,
+    ) {
+        $this->scopes        = new Scopes($withDefaultScopes);
         $this->state         = State::createWithRandomString();
         $this->codeChallenge = Challenge::createWithRandomString();
     }
@@ -45,19 +48,8 @@ class AuthenticationUriBuilder
         return $this->codeChallenge;
     }
 
-    public function withoutDefaultScope(): self
-    {
-        $this->withDefaultScopes = false;
-
-        return $this;
-    }
-
     public function withScopes(string ...$scopes): self
     {
-        if ($this->withDefaultScopes === false) {
-            $this->scopes = new Scopes(false);
-        }
-
         foreach ($scopes as $scope) {
             $this->scopes->addScope(new Scope($scope));
         }

--- a/src/Authentication/AuthenticationUriBuilder.php
+++ b/src/Authentication/AuthenticationUriBuilder.php
@@ -19,6 +19,8 @@ class AuthenticationUriBuilder
 
     private Scopes    $scopes;
 
+    private bool      $withDefaultScopes = true;
+
     private State     $state;
 
     private Challenge $codeChallenge;
@@ -43,8 +45,19 @@ class AuthenticationUriBuilder
         return $this->codeChallenge;
     }
 
+    public function withoutDefaultScope(): self
+    {
+        $this->withDefaultScopes = false;
+
+        return $this;
+    }
+
     public function withScopes(string ...$scopes): self
     {
+        if ($this->withDefaultScopes === false) {
+            $this->scopes = new Scopes(false);
+        }
+
         foreach ($scopes as $scope) {
             $this->scopes->addScope(new Scope($scope));
         }

--- a/src/Authentication/Models/Scopes.php
+++ b/src/Authentication/Models/Scopes.php
@@ -11,12 +11,14 @@ class Scopes
      */
     private array $scopes;
 
-    public function __construct()
+    public function __construct(bool $withDefaultScopes = true)
     {
         $this->scopes = [];
 
-        foreach (self::DEFAULT_SCOPES as $defaultScope) {
-            $this->addScope(new Scope($defaultScope));
+        if ($withDefaultScopes === true) {
+            foreach (self::DEFAULT_SCOPES as $defaultScope) {
+                $this->addScope(new Scope($defaultScope));
+            }
         }
     }
 

--- a/src/Authentication/Models/Scopes.php
+++ b/src/Authentication/Models/Scopes.php
@@ -11,20 +11,25 @@ class Scopes
      */
     private array $scopes;
 
-    public function __construct(bool $withDefaultScopes = true)
+    public function __construct()
     {
         $this->scopes = [];
 
-        if ($withDefaultScopes === true) {
-            foreach (self::DEFAULT_SCOPES as $defaultScope) {
-                $this->addScope(new Scope($defaultScope));
-            }
+        foreach (self::DEFAULT_SCOPES as $defaultScope) {
+            $this->addScope(new Scope($defaultScope));
         }
     }
 
     public function addScope(Scope $scope): void
     {
         $this->scopes[] = $scope;
+    }
+
+    public function removeScope(Scope $scope): void
+    {
+        $this->scopes = array_filter($this->scopes, function (Scope $existingScope) use ($scope) {
+            return $existingScope->getValue() !== $scope->getValue();
+        });
     }
 
     public function getScopesAsString(): string

--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -36,12 +36,13 @@ class Authenticator
     public function beginAuthentication(
         Uri                            $redirectUri,
         ProviderConfigurationInterface $provider,
+        bool                           $withDefaultScopes = true,
     ): AuthenticationUriBuilder {
         if ($redirectUri->getScheme() !== 'https') {
             throw new InsecureUriException('Redirect URI must use https.');
         }
 
-        $authenticationUriBuilder = new AuthenticationUriBuilder($provider, $redirectUri);
+        $authenticationUriBuilder = new AuthenticationUriBuilder($provider, $redirectUri, $withDefaultScopes);
 
         $state     = $authenticationUriBuilder->getState();
         $challenge = $authenticationUriBuilder->getCodeChallenge();

--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -35,7 +35,7 @@ class Authenticator
      */
     public function beginAuthentication(
         Uri                            $redirectUri,
-        ProviderConfigurationInterface $provider
+        ProviderConfigurationInterface $provider,
     ): AuthenticationUriBuilder {
         if ($redirectUri->getScheme() !== 'https') {
             throw new InsecureUriException('Redirect URI must use https.');

--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -35,14 +35,13 @@ class Authenticator
      */
     public function beginAuthentication(
         Uri                            $redirectUri,
-        ProviderConfigurationInterface $provider,
-        bool                           $withDefaultScopes = true,
+        ProviderConfigurationInterface $provider
     ): AuthenticationUriBuilder {
         if ($redirectUri->getScheme() !== 'https') {
             throw new InsecureUriException('Redirect URI must use https.');
         }
 
-        $authenticationUriBuilder = new AuthenticationUriBuilder($provider, $redirectUri, $withDefaultScopes);
+        $authenticationUriBuilder = new AuthenticationUriBuilder($provider, $redirectUri);
 
         $state     = $authenticationUriBuilder->getState();
         $challenge = $authenticationUriBuilder->getCodeChallenge();

--- a/tests/Unit/Authentication/AuthenticationUriBuilderTest.php
+++ b/tests/Unit/Authentication/AuthenticationUriBuilderTest.php
@@ -186,10 +186,10 @@ class AuthenticationUriBuilderTest extends TestCase
 
         $redirectUri = new Uri('https://uri.test/redirect');
 
-        $authenticationUriBuilder = new AuthenticationUriBuilder($provider, $redirectUri, false);
+        $authenticationUriBuilder = new AuthenticationUriBuilder($provider, $redirectUri);
 
         // Act
-        $generatedUri = $authenticationUriBuilder->withScopes('foo', 'bar')->uri();
+        $generatedUri = $authenticationUriBuilder->withoutScopes('openid')->withScopes('foo', 'bar')->uri();
 
         $this->assertEquals($authorizationEndpoint->getHost(), $generatedUri->getHost());
         $this->assertEquals($authorizationEndpoint->getAuthority(), $generatedUri->getAuthority());

--- a/tests/Unit/Authentication/AuthenticationUriBuilderTest.php
+++ b/tests/Unit/Authentication/AuthenticationUriBuilderTest.php
@@ -186,10 +186,10 @@ class AuthenticationUriBuilderTest extends TestCase
 
         $redirectUri = new Uri('https://uri.test/redirect');
 
-        $authenticationUriBuilder = new AuthenticationUriBuilder($provider, $redirectUri);
+        $authenticationUriBuilder = new AuthenticationUriBuilder($provider, $redirectUri, false);
 
         // Act
-        $generatedUri = $authenticationUriBuilder->withoutDefaultScope()->withScopes('foo', 'bar')->uri();
+        $generatedUri = $authenticationUriBuilder->withScopes('foo', 'bar')->uri();
 
         $this->assertEquals($authorizationEndpoint->getHost(), $generatedUri->getHost());
         $this->assertEquals($authorizationEndpoint->getAuthority(), $generatedUri->getAuthority());

--- a/tests/Unit/Authentication/AuthenticationUriBuilderTest.php
+++ b/tests/Unit/Authentication/AuthenticationUriBuilderTest.php
@@ -163,4 +163,48 @@ class AuthenticationUriBuilderTest extends TestCase
         $this->assertEquals('S256', $generatedQuery['code_challenge_method']);
         $this->assertEquals(43, strlen($generatedQuery['code_challenge']));
     }
+
+    /**
+     * @test
+     */
+    public function uri_WithoutDefaultScopeAndWithAdditionalScopes_ReturnsExpectedUri(): void
+    {
+        // Assemble
+        $identifier            = new Identifier('identifier');
+        $clientId              = new ClientId('client-id');
+        $clientSecret          = new ClientSecret('client-secret');
+        $authorizationEndpoint = new Uri('https://endpoint.test/authorization');
+        $tokenEndpoint         = new Uri('https://endpoint.test/token');
+
+        $provider = new ProviderConfiguration(
+            $identifier,
+            $clientId,
+            $clientSecret,
+            $authorizationEndpoint,
+            $tokenEndpoint
+        );
+
+        $redirectUri = new Uri('https://uri.test/redirect');
+
+        $authenticationUriBuilder = new AuthenticationUriBuilder($provider, $redirectUri);
+
+        // Act
+        $generatedUri = $authenticationUriBuilder->withoutDefaultScope()->withScopes('foo', 'bar')->uri();
+
+        $this->assertEquals($authorizationEndpoint->getHost(), $generatedUri->getHost());
+        $this->assertEquals($authorizationEndpoint->getAuthority(), $generatedUri->getAuthority());
+        $this->assertEquals($authorizationEndpoint->getFragment(), $generatedUri->getFragment());
+        $this->assertEquals($authorizationEndpoint->getPath(), $generatedUri->getPath());
+        $this->assertEquals($authorizationEndpoint->getScheme(), $generatedUri->getScheme());
+
+        parse_str($generatedUri->getQuery(), $generatedQuery);
+
+        $this->assertEquals('code', $generatedQuery['response_type']);
+        $this->assertEquals($clientId->getValue(), $generatedQuery['client_id']);
+        $this->assertEquals((string)$redirectUri, $generatedQuery['redirect_uri']);
+        $this->assertEquals('foo bar', $generatedQuery['scope']);
+        $this->assertEquals(16, strlen($generatedQuery['state']));
+        $this->assertEquals('S256', $generatedQuery['code_challenge_method']);
+        $this->assertEquals(43, strlen($generatedQuery['code_challenge']));
+    }
 }

--- a/tests/Unit/Authentication/Models/ScopesTest.php
+++ b/tests/Unit/Authentication/Models/ScopesTest.php
@@ -23,18 +23,6 @@ class ScopesTest extends TestCase
     /**
      * @test
      */
-    public function construct_CreatesScopesWithoutDefaults(): void
-    {
-        // Assemble
-        $scopes = new Scopes(false);
-
-        // Assert
-        $this->assertEquals('', $scopes->getScopesAsString());
-    }
-
-    /**
-     * @test
-     */
     public function addScope_RandomScope_ExpectDefaultWithNewScope(): void
     {
         // Assemble
@@ -45,21 +33,6 @@ class ScopesTest extends TestCase
 
         // Assert
         $this->assertEquals('openid foo', $scopes->getScopesAsString());
-    }
-
-    /**
-     * @test
-     */
-    public function addScope_RandomScope_ExpectNewScopeWithoutDefault(): void
-    {
-        // Assemble
-        $scopes = new Scopes(false);
-
-        // Act
-        $scopes->addScope(new Scope('foo'));
-
-        // Assert
-        $this->assertEquals('foo', $scopes->getScopesAsString());
     }
 
     /**
@@ -81,12 +54,28 @@ class ScopesTest extends TestCase
     /**
      * @test
      */
-    public function addScope_MultipleScopes_ExpectNewScopesWithoutDefault(): void
+    public function removeScope_DefaultScope_RemovesDefaultScope(): void
     {
         // Assemble
-        $scopes = new Scopes(false);
+        $scopes = new Scopes();
 
         // Act
+        $scopes->removeScope(new Scope('openid'));
+
+        // Assert
+        $this->assertEquals('', $scopes->getScopesAsString());
+    }
+
+    /**
+     * @test
+     */
+    public function removeScopeThenAddScope_MultipleScopes_RemovesDefaultScopeAndAddsNewScopes(): void
+    {
+        // Assemble
+        $scopes = new Scopes();
+
+        // Act
+        $scopes->removeScope(new Scope('openid'));
         $scopes->addScope(new Scope('foo'));
         $scopes->addScope(new Scope('bar'));
 

--- a/tests/Unit/Authentication/Models/ScopesTest.php
+++ b/tests/Unit/Authentication/Models/ScopesTest.php
@@ -23,6 +23,18 @@ class ScopesTest extends TestCase
     /**
      * @test
      */
+    public function construct_CreatesScopesWithoutDefaults(): void
+    {
+        // Assemble
+        $scopes = new Scopes(false);
+
+        // Assert
+        $this->assertEquals('', $scopes->getScopesAsString());
+    }
+
+    /**
+     * @test
+     */
     public function addScope_RandomScope_ExpectDefaultWithNewScope(): void
     {
         // Assemble
@@ -33,6 +45,21 @@ class ScopesTest extends TestCase
 
         // Assert
         $this->assertEquals('openid foo', $scopes->getScopesAsString());
+    }
+
+    /**
+     * @test
+     */
+    public function addScope_RandomScope_ExpectNewScopeWithoutDefault(): void
+    {
+        // Assemble
+        $scopes = new Scopes(false);
+
+        // Act
+        $scopes->addScope(new Scope('foo'));
+
+        // Assert
+        $this->assertEquals('foo', $scopes->getScopesAsString());
     }
 
     /**
@@ -49,5 +76,21 @@ class ScopesTest extends TestCase
 
         // Assert
         $this->assertEquals('openid foo bar', $scopes->getScopesAsString());
+    }
+
+    /**
+     * @test
+     */
+    public function addScope_MultipleScopes_ExpectNewScopesWithoutDefault(): void
+    {
+        // Assemble
+        $scopes = new Scopes(false);
+
+        // Act
+        $scopes->addScope(new Scope('foo'));
+        $scopes->addScope(new Scope('bar'));
+
+        // Assert
+        $this->assertEquals('foo bar', $scopes->getScopesAsString());
     }
 }


### PR DESCRIPTION
# Description of Changes
This change add the ability to remove the default `openid` scope. This is necessary for some Oauth providers who do not accept that scope.

## Resolves
<!-- Jira ticket numbers. Separate each with a new line. e.g. DEV-1234 -->

## Blocked By
<!-- Github Pull Request numbers. Separate each with a new line. e.g. #1234 -->

## Testing
<!-- Steps on how to test these changes. -->

Steps:
1. Create a new Authentication object, and in the 3rd parameter of the `beginAuthentication` method, pass false.
2. URL will be generated without the default `openid` scope.

## Checklist
<!--
    Please verify the following.
    If any boxes are unchecked, please provide a reason in the additional information section.
-->
<!-- A filled checkbox should look like this: [x] -->
- [ ] I have labeled this PR appropriately. 
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have created tests to show the ticket has been resolved.
- [ ] I have self-reviewed my completed code.
- [ ] I have tested my changes as well as any areas that may be affected by the change.

## Additional Information
<!-- Please provide any additional information regarding your changes. -->
